### PR TITLE
Fix price formatting in booking pages

### DIFF
--- a/frontend/src/components/booking/AccommodationStep.js
+++ b/frontend/src/components/booking/AccommodationStep.js
@@ -499,7 +499,7 @@ const AccommodationStep = ({ bookingData, availableAccommodations, onBookingData
                             color={theme.palette.primary.main} 
                             sx={{ fontWeight: 700 }}
                           >
-                            ${accommodation.pricePerNight.toLocaleString()}
+                            {`$${accommodation.pricePerNight.toLocaleString()}`}
                           </Typography>
                           <Typography variant="caption" color="rgba(255, 255, 255, 0.7)">
                             per night
@@ -706,10 +706,10 @@ const AccommodationStep = ({ bookingData, availableAccommodations, onBookingData
                             >
                               <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
                                 <Typography variant="body2" color="rgba(255, 255, 255, 0.7)">
-                                  ${accommodation.pricePerNight.toLocaleString()} × {duration} nights
+                                  {`$${accommodation.pricePerNight.toLocaleString()} × ${duration} nights`}
                                 </Typography>
                                 <Typography variant="body2" color="white" fontWeight={500}>
-                                  ${(accommodation.pricePerNight * duration).toLocaleString()}
+                                  {`$${(accommodation.pricePerNight * duration).toLocaleString()}`}
                                 </Typography>
                               </Box>
                               
@@ -800,7 +800,7 @@ const AccommodationStep = ({ bookingData, availableAccommodations, onBookingData
                       {bookingData.accommodation.name}
                     </Typography>
                     <Typography variant="body2" color="rgba(255, 255, 255, 0.7)">
-                      {duration} nights at ${bookingData.accommodation.pricePerNight.toLocaleString()} per night
+                      {`${duration} nights at $${bookingData.accommodation.pricePerNight.toLocaleString()} per night`}
                     </Typography>
                   </Box>
                 </Box>

--- a/frontend/src/pages/AccommodationsPage.js
+++ b/frontend/src/pages/AccommodationsPage.js
@@ -981,7 +981,7 @@ const AccommodationsPage = () => {
                         }}
                       >
                         <Typography variant="h6" sx={{ fontWeight: 700, color: theme.palette.primary.main }}>
-                          ${accommodation.price.toLocaleString()}
+                          {`$${accommodation.price.toLocaleString()}`}
                         </Typography>
                         <Typography variant="caption" sx={{ display: 'block', textAlign: 'center' }}>
                           {accommodation.perNight ? 'per night' : 'per stay'}

--- a/frontend/src/pages/DestinationsPage.js
+++ b/frontend/src/pages/DestinationsPage.js
@@ -62,9 +62,9 @@ const DestinationsPage = () => {
                 </Typography>
                 
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 2 }}>
-                  <Typography variant="h6" color="primary">
-                    From ${destination.basePrice.toLocaleString()}
-                  </Typography>
+                    <Typography variant="h6" color="primary">
+                      {`From $${destination.basePrice.toLocaleString()}`}
+                    </Typography>
                   <Typography variant="body2" color="text.secondary">
                     Next launch: {destination.nextLaunch}
                   </Typography>

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -731,7 +731,7 @@ const HomePage = () => {
                     >
                       <RocketLaunchIcon />
                     </Box>
-                    From ${destination.price.toLocaleString()}
+                    {`From $${destination.price.toLocaleString()}`}
                   </Typography>
                 </CardContent>
                 


### PR DESCRIPTION
## Summary
- fix currency formatting on destination, home, and accommodation pages
- correct booking page price displays

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6c72408483288ef34a1434b48768